### PR TITLE
Replaces deprecated `typeface-roboto` with `@fontsource/roboto`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "reactsigninwithgooglebutton",
-  "version": "0.0.2",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reactsigninwithgooglebutton",
-      "version": "0.0.2",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
-        "typeface-roboto": "latest"
+        "@fontsource/roboto": "latest"
       },
       "devDependencies": {
         "@types/react": "latest",
@@ -18,6 +18,11 @@
         "react-dom": "latest",
         "typescript": "latest"
       }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -109,11 +114,6 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/typeface-roboto": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-roboto/-/typeface-roboto-1.1.13.tgz",
-      "integrity": "sha512-YXvbd3a1QTREoD+FJoEkl0VQNJoEjewR2H11IjVv4bp6ahuIcw0yyw/3udC4vJkHw3T3cUh85FTg8eWef3pSaw=="
-    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -129,6 +129,11 @@
     }
   },
   "dependencies": {
+    "@fontsource/roboto": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
+    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -209,11 +214,6 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
-    },
-    "typeface-roboto": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-roboto/-/typeface-roboto-1.1.13.tgz",
-      "integrity": "sha512-YXvbd3a1QTREoD+FJoEkl0VQNJoEjewR2H11IjVv4bp6ahuIcw0yyw/3udC4vJkHw3T3cUh85FTg8eWef3pSaw=="
     },
     "typescript": {
       "version": "4.9.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "dependencies": {
-    "typeface-roboto": "latest"
+    "@fontsource/roboto": "latest"
   },
   "devDependencies": {
     "@types/react": "latest",

--- a/src/SignInWithGoogleButton.tsx
+++ b/src/SignInWithGoogleButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import "typeface-roboto";
+import "@fontsource/roboto";
 
 // Based on
 // https://developers.google.com/identity/gsi/web/tools/configurator

--- a/src/SignInWithGoogleButton.tsx
+++ b/src/SignInWithGoogleButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import "@fontsource/roboto";
+import "@fontsource/roboto/500.css";
 
 // Based on
 // https://developers.google.com/identity/gsi/web/tools/configurator


### PR DESCRIPTION
Hi, thanks for this project, it's just what I needed to work with: https://github.com/MomenSherif/react-oauth as I need an "official" Log In With Google button to pass my scopes audit from Google.

However, I noticed that the `typeface-roboto` dependency is deprecated (see below), so have replaced it with `@fontsource/roboto` instead.  Hope that helps.

> The Typefaces project is now deprecated.
> 
> @DecliningLotus created [FontSource](https://github.com/fontsource/fontsource) which provides the same functionality as Typefaces but with automated releases & richer support for importing specific weights, styles, or language subsets.
