### PR TITLE
Changes to use Google Sans instead of Roboto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
-        "@fontsource/roboto": "latest"
+        "google-sans": "github:agnel/google-sans"
       },
       "devDependencies": {
         "@types/react": "latest",
@@ -18,11 +18,6 @@
         "react-dom": "latest",
         "typescript": "latest"
       }
-    },
-    "node_modules/@fontsource/roboto": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
-      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -61,6 +56,10 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
       "dev": true
+    },
+    "node_modules/google-sans": {
+      "version": "0.0.1",
+      "resolved": "git+ssh://git@github.com/agnel/google-sans.git#3145a902844c56346dca84d3eabebe1aa760ba19"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -129,11 +128,6 @@
     }
   },
   "dependencies": {
-    "@fontsource/roboto": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
-      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
-    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -171,6 +165,10 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
       "dev": true
+    },
+    "google-sans": {
+      "version": "git+ssh://git@github.com/agnel/google-sans.git#3145a902844c56346dca84d3eabebe1aa760ba19",
+      "from": "google-sans@github:agnel/google-sans"
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "dependencies": {
-    "@fontsource/roboto": "latest"
+    "google-sans": "github:agnel/google-sans"
   },
   "devDependencies": {
     "@types/react": "latest",

--- a/src/SignInWithGoogleButton.tsx
+++ b/src/SignInWithGoogleButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import "@fontsource/roboto/500.css";
+import 'google-sans/500.css';
 
 // Based on
 // https://developers.google.com/identity/gsi/web/tools/configurator
@@ -13,7 +13,7 @@ const button : React.CSSProperties = {
   border: '1px solid #dadce0',
   color: '#3c4043',
   cursor: 'pointer',
-  fontFamily: 'Roboto, Verdana',
+  fontFamily: 'Google Sans, Roboto, Verdana, Arial, sans-serif',
   fontWeight: '500',
   fontSize: '14px',
   height: '40px',


### PR DESCRIPTION
I noticed on https://developers.google.com/identity/gsi/web/tools/configurator that they're actually using `Google Sans` instead of `Roboto` now, so this update changes to use that.

The only package source I could find for Google Sans is: https://github.com/agnel/google-sans but seems to work fine.